### PR TITLE
changed default branch of 4diac-documentation to main

### DIFF
--- a/otterdog/eclipse-4diac.jsonnet
+++ b/otterdog/eclipse-4diac.jsonnet
@@ -55,7 +55,7 @@ orgs.newOrg('eclipse-4diac') {
     orgs.newRepo('4diac-documentation') {
       allow_merge_commit: true,
       allow_update_branch: false,
-      default_branch: "master",
+      default_branch: "main",
       delete_branch_on_merge: false,
       web_commit_signoff_required: false,
     },

--- a/otterdog/eclipse-4diac.jsonnet
+++ b/otterdog/eclipse-4diac.jsonnet
@@ -55,7 +55,6 @@ orgs.newOrg('eclipse-4diac') {
     orgs.newRepo('4diac-documentation') {
       allow_merge_commit: true,
       allow_update_branch: false,
-      default_branch: "main",
       delete_branch_on_merge: false,
       web_commit_signoff_required: false,
     },


### PR DESCRIPTION
accidently used wrong name for default branch in new repo 4diac-documentation