### PR TITLE
changed default branch for 4diac IDE

### DIFF
--- a/otterdog/eclipse-4diac.jsonnet
+++ b/otterdog/eclipse-4diac.jsonnet
@@ -68,7 +68,7 @@ orgs.newOrg('iot.4diac', 'eclipse-4diac') {
     orgs.newRepo('4diac-ide') {
       allow_merge_commit: true,
       allow_update_branch: false,
-      default_branch: "release",
+      default_branch: "develop",
       delete_branch_on_merge: false,
       has_discussions: true,
       web_commit_signoff_required: false,


### PR DESCRIPTION
In difference to the other repos it is better to have the develop branch as the default branch for 4diac IDE